### PR TITLE
Handle pages with a trailing slash or a .html extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,11 @@ function crawl(url, output) {
     //   );
     // });
 
+    crawler.on('fetchclienterror', (queueItem, error) => {
+      console.error("Client error, could not fetch %s", queueItem.url);
+      throw error;
+    });
+
     crawler.on('fetchcomplete', (queueItem, responseBuffer, response) => {
 
       // Parse url
@@ -62,7 +67,15 @@ function crawl(url, output) {
 
       // this ensures that we have .html suffix hidden and directories instead
       } else if (response.headers['content-type'].includes('text/html')) {
-        parsed.pathname += '/index.html';
+        if (parsed.pathname.match(/.html?$/)) {
+          // Do nothing as the .html file is directly pointed to.
+        } else if (parsed.pathname.match(/\/$/)) {
+          // Trailing slash so the link points to a directory.
+          parsed.pathname += 'index.html';
+        } else {
+          // A pretty URL
+          parsed.pathname += '/index.html';
+        }
       }
 
       // Where to save downloaded data


### PR DESCRIPTION
Currently, this tool (awesome tool by the way) renames everything with appending `'/index.html'`.
With this commit it will not rename urls that have already a .html extension, and correctly handles "directory" urls with appending only `'index.html'`.

Also, I added an event listener to print client errors, useful when your computer looses connexion, as the current version does not fail and termintates silently.